### PR TITLE
Makes the test respond to the correct error.

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -66,7 +66,7 @@ describe("filterProductsByPriceRange()", () => {
   });
 
   test("should throw an error if the `min` value is greater than the `max` value", () => {
-    expect(() => filterProductsByPriceRange([], 30000, 10000)).toThrow();
+    expect(() => filterProductsByPriceRange(products, 30000, 10000)).toThrow();
   });
 
   test("should throw an error if either the `min` or `max` value is less than 0", () => {


### PR DESCRIPTION
With an empty array as the first argument, the test will pass if the
student were to throw an error for empty arrays (a different test case).

Using `products` as an argument, as in the other test cases, isolates
the test to _only_ pass if an error is thrown for this particular case.