### PR TITLE
Makes test respond to correct error.

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -48,10 +48,11 @@ describe("filterProductsByPriceRange()", () => {
 
   test("should throw an error if any of the products is missing the `priceInCents` key", () => {
     expect(() =>
-      filterProductsByPriceRange([
-        ...products,
-        { id: 6, name: "L-Shaped Desk" },
-      ])
+      filterProductsByPriceRange(
+        [...products, { id: 6, name: "L-Shaped Desk" }],
+        1000,
+        3000
+      )
     ).toThrow();
   });
 


### PR DESCRIPTION
Without the min and max passed in as arguments, the test passes without
the student checking for the existence of the `priceInCents` key, as long
as they have the checks for the type of `min` or `max`.